### PR TITLE
Prepare release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 All significant changes to **Fedora Setup** will be documented here.
 
-- [Unreleased](#unreleased)
-  - [Added](#added)
-  - [Changed](#changed)
-  - [Removed](#removed)
-  - [Fixed](#fixed)
+- [Released](#released)
+  - [Version 1.0.0 - *2021-05-06*](#version-100---2021-05-06)
 - [Pre releases](#pre-releases)
   - [Version 0.0.2 - *2021-05-04*](#version-002---2021-05-04)
   - [Version 0.0.1 - *2021-05-03*](#version-001---2021-05-03)
 
-## Unreleased
-### Added
+## Released
+
+### Version [1.0.0](https://github.com/nico-castell/Fedora-Setup/releases/tag/1.0.0) - *2021-05-06*
+This version introduces mainly a new way to load packages from [packages.txt](packages.txt), and a module to switch to systemd-boot. But the majority of the work was debugging.
+#### Added
 - [systemdboot_switch.sh](modules/systemdboot_switch.sh):
   - This new module can switch Fedora's bootloader from **grub** to **systemd-boot**.
 - [fedora_setup.sh](fedora_setup.sh):
@@ -20,7 +20,7 @@ All significant changes to **Fedora Setup** will be documented here.
   - The script now announces that it has finished.
 - [packages.txt](packages.txt):
   - Some new packages were added, such as **C/C++**, **GNOME Boxes**, and more.
-### Changed
+#### Changed
 - [packages.txt](packages.txt):
   - Given the new way fedora_setup.sh loads packages, packages.txt was given a new structure to accomodate this by using spaces as delimiters between the name the user sees and the packages selected. Addinionally this means APPEND_DNF is not as useful now.
 - [fedora_setup.sh](fedora_setup.sh):
@@ -32,12 +32,12 @@ All significant changes to **Fedora Setup** will be documented here.
   - xdg-open was silenced
 - [gnome_settings.hs](modules/gnome_settings.sh):
   - `favorite-apps` config was deleted, and a few other settings were regrouped.
-### Removed
+#### Removed
 - [fedora_setup.sh](fedora_setup.sh):
   - Given the new way packages are loaded, the following were removed, in favor of loading them when the user selects their package (TO_DNF):
     - **C/C++** was removed from APPEND_DNF when choosing packages to append to Visual Studio Code.
     - **zsh** and **@development-tools** no longer contribute to APPEND_DNF.
-### Fixed
+#### Fixed
 - **NOTE:** The project was tested on a VM to find and fix errors.
 - [mc_server_builder.sh](modules/mc_server_builder.sh):
   - The location of the image file was fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All significant changes to **Fedora Setup** will be documented here.
   - [Added](#added)
   - [Changed](#changed)
   - [Removed](#removed)
+  - [Fixed](#fixed)
 - [Pre releases](#pre-releases)
   - [Version 0.0.2 - *2021-05-04*](#version-002---2021-05-04)
   - [Version 0.0.1 - *2021-05-03*](#version-001---2021-05-03)
@@ -16,18 +17,38 @@ All significant changes to **Fedora Setup** will be documented here.
   - This new module can switch Fedora's bootloader from **grub** to **systemd-boot**.
 - [fedora_setup.sh](fedora_setup.sh):
   - Introduced a new way of loading and selecting packages. The user can now see the name of the app eg **Z-Shell**, confirm the package, and load multiple packages, eg **zsh zsh-autosuggestions \+**.
+  - The script now announces that it has finished.
 - [packages.txt](packages.txt):
   - Some new packages were added, such as **C/C++**, **GNOME Boxes**, and more.
 ### Changed
 - [packages.txt](packages.txt):
   - Given the new way fedora_setup.sh loads packages, packages.txt was given a new structure to accomodate this by using spaces as delimiters between the name the user sees and the packages selected. Addinionally this means APPEND_DNF is not as useful now.
+- [fedora_setup.sh](fedora_setup.sh):
+  - When the user chooses to upgrade, `dnf` will assume yes, instead of prompting for confirmation, again.
+  - PackageKit is now restarted *after* running the modules.
 - [vscode.sh](vscode.sh):
   - Updated git aliases `flog` and `sflog`.
+- [gnome_extensions.sh](modules/gnome_extensions.sh):
+  - xdg-open was silenced
+- [gnome_settings.hs](modules/gnome_settings.sh):
+  - `favorite-apps` config was deleted, and a few other settings were regrouped.
 ### Removed
 - [fedora_setup.sh](fedora_setup.sh):
   - Given the new way packages are loaded, the following were removed, in favor of loading them when the user selects their package (TO_DNF):
     - **C/C++** was removed from APPEND_DNF when choosing packages to append to Visual Studio Code.
-    - **zsh** and **@development-tools** no longer contribute to APPEND_DNF
+    - **zsh** and **@development-tools** no longer contribute to APPEND_DNF.
+### Fixed
+- **NOTE:** The project was tested on a VM to find and fix errors.
+- [mc_server_builder.sh](modules/mc_server_builder.sh):
+  - The location of the image file was fixed.
+- [fedora_setup.sh](fedora_setup.sh):
+  - The output was cleaned up.
+  - Modules are now running properly.
+  - Fixed backing up files such as *.bashrc*, *.clang-format*, *.zshrc*, *.vimrc*.
+  - Fixed Brave Browser source config outputting the .repo file to the console.
+  - Many syntax errors were fixed.
+- [vscode.sh](vscode.sh):
+  - Fixed how the script would offer configurations even if it wasn't sourced properly.
 
 ## Pre releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,32 @@
 
 All significant changes to **Fedora Setup** will be documented here.
 
+- [Unreleased](#unreleased)
+  - [Added](#added)
+  - [Changed](#changed)
+  - [Removed](#removed)
 - [Pre releases](#pre-releases)
   - [Version 0.0.2 - *2021-05-04*](#version-002---2021-05-04)
   - [Version 0.0.1 - *2021-05-03*](#version-001---2021-05-03)
+
+## Unreleased
+### Added
+- [systemdboot_switch.sh](modules/systemdboot_switch.sh):
+  - This new module can switch Fedora's bootloader from **grub** to **systemd-boot**.
+- [fedora_setup.sh](fedora_setup.sh):
+  - Introduced a new way of loading and selecting packages. The user can now see the name of the app eg **Z-Shell**, confirm the package, and load multiple packages, eg **zsh zsh-autosuggestions \+**.
+- [packages.txt](packages.txt):
+  - Some new packages were added, such as **C/C++**, **GNOME Boxes**, and more.
+### Changed
+- [packages.txt](packages.txt):
+  - Given the new way fedora_setup.sh loads packages, packages.txt was given a new structure to accomodate this by using spaces as delimiters between the name the user sees and the packages selected. Addinionally this means APPEND_DNF is not as useful now.
+- [vscode.sh](vscode.sh):
+  - Updated git aliases `flog` and `sflog`.
+### Removed
+- [fedora_setup.sh](fedora_setup.sh):
+  - Given the new way packages are loaded, the following were removed, in favor of loading them when the user selects their package (TO_DNF):
+    - **C/C++** was removed from APPEND_DNF when choosing packages to append to Visual Studio Code.
+    - **zsh** and **@development-tools** no longer contribute to APPEND_DNF
 
 ## Pre releases
 

--- a/fedora_setup.sh
+++ b/fedora_setup.sh
@@ -90,7 +90,6 @@ if ! $load_tmp_file: then
 		printf "I noticed you're installing \e[36mvscode\e[00m...\n"
 
 		 LIST=("nodejs")                                                   # NodeJS
-		LIST+=("@c-development" "clang" "cmake")                           # C/C++
 		LIST+=("java-latest-openjdk-devel" "@eclipse")                     # Java
 		LIST+=("dotnet-sdk-5.0" "dotnet-sdk-3.1" "aspnetcore-runtime-3.1") # .NET
 

--- a/fedora_setup.sh
+++ b/fedora_setup.sh
@@ -66,10 +66,10 @@ if ! $load_tmp_file: then
 	# install.
 	IFSB="$IFS"
 	IFS="$(echo -en "\n\b")"
-	for i in $(cat "$packages_file" | cut -d ' ' -f 1); do
-		read -r -p "Confirm: `tput setaf 3``printf %s $i | tr '_' ' '``tput sgr0` (Y/n) "
+	for i in $(cat "$packages_file"); do
+		read -r -p "Confirm: `tput setaf 3``printf %s $i | cut -d ' ' -f 1 | tr '_' ' '``tput sgr0` (Y/n) "
 		[[ ${REPLY,,} == "y" ]] || [ -z $REPLY ] && \
-		TO_DNF+=("$(cat packages.txt | grep "$i" | cut -d ' ' -f 2-)")
+		TO_DNF+=("$(printf %s "$i" | cut -d ' ' -f 2-)")
 	done
 	IFS="$IFSB"
 	unset IFSB

--- a/fedora_setup.sh
+++ b/fedora_setup.sh
@@ -164,6 +164,10 @@ if ! $load_tmp_file: then
 	INSTALL_DUC=$Confimed
 	test $INSTALL_DUC && Modules+=("INSTALL_DUC")
 
+	prompt_user "systemdboot_switch.sh" "switch to systemd-boot"
+	SYSTEMDBOOT_SWITCH=$Confimed
+	test $SYSTEMDBOOT_SWITCH && Modules+=("SYSTEMDBOOT_SWITCH")
+
 	printf "MODULES - %s\n" "${Modules[@]}" >> "$choices_file"
 	Separate 4
 fi
@@ -397,20 +401,23 @@ fi
 sudo systemctl restart packagekit
 
 # Run modules
-if [ $GNOME_APPEARANCE ]; then
+if [ $GNOME_APPEARANCE   ]; then
 	"$modules_folder/gnome_appearance.sh"
 fi
-if [ $GNOME_SETTINGS   ]; then
+if [ $GNOME_SETTINGS     ]; then
 	"$modules_folder/gnome_settings.sh"
 fi
-if [ $GNOME_EXTENSIONS ]; then
+if [ $GNOME_EXTENSIONS   ]; then
 	"$modules_folder/gnome_extensions.sh"
 fi
-if [ $BUILD_MC_SERVER  ]; then
+if [ $BUILD_MC_SERVER    ]; then
 	"$modules_folder/mc_server_builder.sh"
 fi
-if [ $INSTALL_DUC      ]; then
+if [ $INSTALL_DUC        ]; then
 	"$modules_folder/duc_noip_install.sh" -e
+fi
+if [ $SYSTEMDBOOT_SWITCH ]; then
+	"$modules_folder/systemdboot_switch.sh"
 fi
 
 # Clean up after we're done

--- a/modules/gnome_extensions.sh
+++ b/modules/gnome_extensions.sh
@@ -5,10 +5,10 @@
 # THE SOFTWARE IS PROVIDED "AS IS"
 # Read the included LICENSE file for more information
 
-(xdg-open "https://extensions.gnome.org/extension/906/sound-output-device-chooser/") &
-(xdg-open "https://extensions.gnome.org/extension/97/coverflow-alt-tab/") &
-(xdg-open "https://extensions.gnome.org/extension/307/dash-to-dock/") &
-(xdg-open "https://extensions.gnome.org/extension/779/clipboard-indicator/") &
+(xdg-open "https://extensions.gnome.org/extension/906/sound-output-device-chooser/" &>/dev/null) &
+(xdg-open "https://extensions.gnome.org/extension/97/coverflow-alt-tab/" &>/dev/null) &
+(xdg-open "https://extensions.gnome.org/extension/307/dash-to-dock/" &>/dev/null) &
+(xdg-open "https://extensions.gnome.org/extension/779/clipboard-indicator/" &>/dev/null) &
 
 read -p "Press enter to continue... "
 

--- a/modules/gnome_settings.sh
+++ b/modules/gnome_settings.sh
@@ -24,18 +24,13 @@ gsettings set org.gnome.calculator refresh-interval 86400
 # Configuring interface.
 echo "Configuring interface..."
 gsettings set org.gnome.desktop.wm.preferences button-layout "close:appmenu"
-gsettings set org.gnome.shell favorite-apps ['brave-browser.desktop', 'org.gnome.Geary.desktop', 'brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default.desktop', 'browser-msoffice.desktop', 'org.gnome.Calendar.desktop', 'code.desktop', 'org.gnome.Nautilus.desktop', 'spotify.desktop']
-
-echo "Configuring interface behaviour..."
 gsettings set org.gnome.mutter center-new-windows true
 gsettings set org.gnome.desktop.wm.preferences action-middle-click-titlebar minimize
 gsettings set org.gnome.SessionManager logout-prompt false
 
 # Configuring peripherals.
-echo "Configuring mouse..."
+echo "Configuring mouse and touchpad..."
 gsettings set org.gnome.desktop.peripherals.mouse accel-profile flat
-
-echo "Configuring touchpad..."
 gsettings set org.gnome.desktop.peripherals.touchpad click-method fingers
 gsettings set org.gnome.desktop.peripherals.touchpad natural-scroll true
 gsettings set org.gnome.desktop.peripherals.touchpad speed 0.5

--- a/modules/mc_server_builder.sh
+++ b/modules/mc_server_builder.sh
@@ -147,7 +147,7 @@ wget -q "$download_link" -O server.jar ; code_1=$?
 
 # Copy server icon
 code_2=0
-cp "$script_location/assets/mcserver/server-icon.png" . ; code_2=$?
+cp "$script_location/../assets/mcserver/server-icon.png" . ; code_2=$?
 
 #region run_file =============================================================
 run_file="#!/bin/bash

--- a/modules/systemdboot_switch.sh
+++ b/modules/systemdboot_switch.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+###############################################################
+# WARNING: THIS SCRIPT COULD BREAK YOUR BOOT - USE WITH CAUTION
+###############################################################
+
+# This way of switching is based on an article at:
+#   https://kowalski7cc.xyz/blog/systemd-boot-fedora-32
+
+# Switching to systemd-boot required removing grub.
+printf "\e[33mSwitching to systemd-boot requires removing grub.\e[00m
+A new EFI boot entry will be created and your boot partition will be mounted at \e[01m/efi\e[00m.
+It's not recommendable to use systemd-boot if your boot partition is small (I recommend 512 MiB).\n\n"
+
+PROCEED=false
+read -rp "Now that you understand the risk, do you still want to switch? (y/N) "
+[[ ${REPLY,,} == "y" ]] && PROCEED=true
+
+# Switch to systemd-boot
+if $PROCEED; then
+	printf "Switching now. \e[01;31mDO NOT REBOOT OR CANCEL\e[00m...\n"
+
+	# Need sudo privileges
+	sudo echo >/dev/null
+
+	# systemd-boot is not for Legacy boot. So we can't switch if the system doesn't use UEFI.
+	if test ! -d /sys/firmware/efi; then
+		printf "YOUR SYSTEM DOESN'T USE EFI BOOT, cannot switch to systemd-boot.\n" >&2
+		exit 2
+	fi
+
+	# Find some necessary packages
+	for i in blkid sed awk cut cat sudo grep kernel-install; do
+		if ! which $i; do
+			printf "Missing required package: %s\n" $i
+			exit 3
+		done
+	done
+
+	# Prepare directory and make a backup of the /etc/fstab
+	sudo mkdir /efi
+	sudo cp /etc/fstab /etc/fstab-og
+
+	# Get the UUID of the EFI partition
+	ID=$(sudo blkid | grep EFI | cut -d ' ' -f 3)
+	ID=${ID//\"/}
+
+	# Get the current mountpoint of the boot partition
+	MOUNT=$(cat /etc/fstab | grep "$ID" | awk '{print $2}')
+
+	# Move the partition to /efi only if it's not already there
+	if ! [[ "$MOUNT" == '/efi' ]]; then
+		printf "Moving boot partition, \e[01;31mDO NOT REBOOT OR CANCEL\e[00m...\n"
+		PART=${MOUNT//\//\\/}                   # eg /boot/efi -> \/boot\/efi
+		sudo sed -i "s/$PART/\/efi/" /etc/fstab # Edit fstab
+
+		if [ $? -eq 0 ]; then
+			sudo umount $MOUNT
+			sudo mount /efi
+		fi
+	fi
+
+	# Make directory for systemd-boot
+	sudo mkdir /efi/$(cat /etc/machine-id)
+
+	# Remove grub, grubby and shim
+	printf "Removing grub, \e[01;31mDO NOT REBOOT OR CANCEL\e[00m...\n"
+	[ $? -eq 0 ] && rm /etc/dnf/protected.d/grub* /etc/dnf/protected.d/shim* && \
+	sudo dnf remove -y grubby grub2* shim* memtest86* && \
+	sudo rm -rf /boot/grub2 && sudo rm -rf /boot/loader
+
+	# Install systemd-boot
+	printf "Installing systemd-boot, \e[01;31mDO NOT REBOOT OR CANCEL\e[00m...\n"
+	cat /proc/cmdline | cud -d ' ' -f 2- | sudo tee /etc/kernel/cmdline
+	sudo bootctl install
+	sudo kernel-install add $(uname -r) /lib/modules/$(uname -r)/vmlinuz
+
+	# Reinstall kernel
+	printf "Reinstalling kernel, \e[01;31mDO NOT REBOOT OR CANCEL\e[00m...\n"
+	sudo dnf reinstall kernel-core -y
+
+	# Give notice the process is finished
+	[ $? -eq 0 ] && printf "\e[01;32mSuccess!\e[00m it is now safe to reboot.\n"
+
+else
+	exit 1
+fi
+
+exit 0
+
+# Exit codes:
+# 0 - All good
+# 1 - User canceled the switch
+# 2 - System uses Legacy boot
+# 3 - Missing package/s

--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,6 @@
 Development_Tools @development-tools git git-lfs
 Libre_Office @libreoffice
+C/C++_development @c-development cmake clang
 Audacity audacity
 Brave_Browser brave-browser
 cmatrix cmatrix
@@ -9,11 +10,12 @@ Discord discord
 Flatpak flatpak
 Geary_Mail geary
 GIMP gimp
+GNOME_Boxes gnome-boxes
 GNOME_Chess gnome-chess
 GNOME_Mines gnome-mines
 GNOME_Power-Manager gnome-power-manager
 GNOME_Tweaks gnome-tweaks
-Gparted gparted
+GParted gparted
 Grub_Customizer grub-customizer os-prober
 HTOP htop
 Inkscape inkscape

--- a/packages.txt
+++ b/packages.txt
@@ -14,14 +14,12 @@ GNOME_Mines gnome-mines
 GNOME_Power-Manager gnome-power-manager
 GNOME_Tweaks gnome-tweaks
 Gparted gparted
-Grub_Customizer grub-customizer
-hddtemp hddtemp
+Grub_Customizer grub-customizer os-prober
 HTOP htop
 Inkscape inkscape
 Java_OpenJDK java-latest-openjdk
-LM_Sensors lm_sensors
+LM_Sensors lm_sensors hddtemp
 OBS_Studio obs-studio
-OS_Prober os-prober
 7zip p7zip
 Passwords_and_Keys seahorse gpgme
 Steam steam

--- a/packages.txt
+++ b/packages.txt
@@ -1,32 +1,33 @@
-@development-tools
-audacity
-brave-browser
-cmatrix
-code
-dconf-editor
-discord
-flatpak
-geary
-gimp
-gnome-chess
-gnome-mines
-gnome-power-manager
-gnome-tweaks
-gparted
-grub-customizer
-hddtemp
-htop
-inkscape
-java-latest-openjdk
-lm_sensors
-obs-studio
-os-prober
-p7zip
-seahorse
-steam
-thunderbird
-tlp
-tree
-virtualbox
-vlc
-zsh
+Development_Tools @development-tools git git-lfs
+Libre_Office @libreoffice
+Audacity audacity
+Brave_Browser brave-browser
+cmatrix cmatrix
+Visual_Studio_Code code git
+dconf-Editor dconf-editor
+Discord discord
+Flatpak flatpak
+Geary_Mail geary
+GIMP gimp
+GNOME_Chess gnome-chess
+GNOME_Mines gnome-mines
+GNOME_Power-Manager gnome-power-manager
+GNOME_Tweaks gnome-tweaks
+Gparted gparted
+Grub_Customizer grub-customizer
+hddtemp hddtemp
+HTOP htop
+Inkscape inkscape
+Java_OpenJDK java-latest-openjdk
+LM_Sensors lm_sensors
+OBS_Studio obs-studio
+OS_Prober os-prober
+7zip p7zip
+Passwords_and_Keys seahorse gpgme
+Steam steam
+Thunderbird thunderbird
+TLP tlp powertop
+Tree tree
+Virtual_Box VirtualBox
+VLC vlc
+Z-Shell zsh zsh-syntax-highlighting zsh-autosuggestions python3-pip util-linux-user

--- a/vscode.sh
+++ b/vscode.sh
@@ -59,10 +59,9 @@ case $c in
 	# Set up aliases
 	printf "Setting up some Git aliases...\n"
 	git config --global alias.mrc '!git merge $1 && git commit -m "$2" --allow-empty && :'
-	git config --global alias.flog "log --all --graph --oneline --format=format:'%C(bold white)%h%C(r) -- %C(blue)%an (%ar)%C(r): %s %C(auto)%d%C(r)'"
-	git config --global alias.sflog "log --all --graph --oneline --format=format:'%C(bold white)%h%C(r) -- %C(yellow)%G?%C(r) %C(blue)%an (%ar)%C(r): %s %C(auto)%d%C(r)'"
+	git config --global alias.flog "log --all --graph --oneline --format=format:'%C(bold yellow)%h%C(r) %an➜ %C(bold)%s%C(r) %C(auto)%d%C(r)\'"
+	git config --global alias.sflog "log --all --graph --oneline --format=format:'%C(bold yellow)%h%C(r) §%C(bold green)%G?%C(r) %an➜ %C(bold)%s%C(r) %C(auto)%d%C(r)'"
 	git config --global alias.slog 'log --show-signature -1'
-	git config --global alias.fflog 'log --graph'
 	git config --global alias.mkst 'stash push -u'
 	git config --global alias.popst 'stash pop "stash@{0}" -q'
 	git config --global alias.unstage 'reset -q HEAD -- .'

--- a/vscode.sh
+++ b/vscode.sh
@@ -5,16 +5,15 @@
 # from fedora_setup.sh because it depends on variables declared in
 # fedora_setup.sh
 
+[[ ${TO_DNF[@]} == *"git"* ]]        && LIST+=("Git with vscode")
+[[ ${APPEND_DNF[@]} == *"nodejs"* ]] && LIST+=("VS Code Extension development")
+
+# Do not run if the package is not being sourced
+if [[ "$0" == *"vscode.sh" ]] && [ ! -z "$LIST" ]; then
 Separate 4
 printf "Successfully installed \e[36mVisual Studio Code\e[00m, configuring...\n"
 printf "Choose some developer tools to prepare:\n"
 
-[[ ${TO_DNF[@]} == *"@development-tools"* ]] && LIST+=("Git with vscode")
-[[ ${APPEND_DNF[@]} == *"nodejs"* ]]         && LIST+=("VS Code Extension development")
-
-# Do not attempt to configure if no packages were installed
-# (Safeguard in case someone tries to run this file without sourcing it properly)
-if [ -n ${TO_DNF[@]} ] && [ -n ${APPEND_DNF[@]} ]; then
 select c in "${LIST[@]}" exit; do
 case $c in
 	"Git with vscode")


### PR DESCRIPTION
<!--
CHECKLIST
Did you...
- Update the CHANGELOG?
- Update the README?
- Comment your code?
- Make a final commit showing the branch is ready to merge:
    :ticket: <message>

Is...
- .gitignore ignoring any temporary files you are adding?
- .gitattributes up to date with your changes?
-->

## "In a nutshell"
This version introduces mainly a new way to load packages from [packages.txt](packages.txt), and a module to switch to systemd-boot. But the majority of the work was debugging.

## Changelog
### Added
- [systemdboot_switch.sh](modules/systemdboot_switch.sh):
  - This new module can switch Fedora's bootloader from **grub** to **systemd-boot**.
- [fedora_setup.sh](fedora_setup.sh):
  - Introduced a new way of loading and selecting packages. The user can now see the name of the app eg **Z-Shell**, confirm the package, and load multiple packages, eg **zsh zsh-autosuggestions \+**.
  - The script now announces that it has finished.
- [packages.txt](packages.txt):
  - Some new packages were added, such as **C/C++**, **GNOME Boxes**, and more.
### Changed
- [packages.txt](packages.txt):
  - Given the new way fedora_setup.sh loads packages, packages.txt was given a new structure to accomodate this by using spaces as delimiters between the name the user sees and the packages selected. Addinionally this means APPEND_DNF is not as useful now.
- [fedora_setup.sh](fedora_setup.sh):
  - When the user chooses to upgrade, `dnf` will assume yes, instead of prompting for confirmation, again.
  - PackageKit is now restarted *after* running the modules.
- [vscode.sh](vscode.sh):
  - Updated git aliases `flog` and `sflog`.
- [gnome_extensions.sh](modules/gnome_extensions.sh):
  - xdg-open was silenced
- [gnome_settings.hs](modules/gnome_settings.sh):
  - `favorite-apps` config was deleted, and a few other settings were regrouped.
### Removed
- [fedora_setup.sh](fedora_setup.sh):
  - Given the new way packages are loaded, the following were removed, in favor of loading them when the user selects their package (TO_DNF):
    - **C/C++** was removed from APPEND_DNF when choosing packages to append to Visual Studio Code.
    - **zsh** and **@development-tools** no longer contribute to APPEND_DNF.
### Fixed
- **NOTE:** The project was tested on a VM to find and fix errors.
- [mc_server_builder.sh](modules/mc_server_builder.sh):
  - The location of the image file was fixed.
- [fedora_setup.sh](fedora_setup.sh):
  - The output was cleaned up.
  - Modules are now running properly.
  - Fixed backing up files such as *.bashrc*, *.clang-format*, *.zshrc*, *.vimrc*.
  - Fixed Brave Browser source config outputting the .repo file to the console.
  - Many syntax errors were fixed.
- [vscode.sh](vscode.sh):
  - Fixed how the script would offer configurations even if it wasn't sourced properly.

<!--
The commit message for merging the request must follow this structure:
    :coffee: PR #X - <description> - Merged 'branch' (into 'branch')
-->
